### PR TITLE
CR : Add central authority and error code and remove hardcoded space

### DIFF
--- a/programs/rarity/src/lib.rs
+++ b/programs/rarity/src/lib.rs
@@ -44,7 +44,7 @@ pub struct AddMetadata<'info> {
     #[account(signer)]
     pub authority: AccountInfo<'info>,
     pub mint: Account<'info, Mint>,
-    #[account(init_if_needed ,seeds = [PREFIX.as_bytes(),mint.key().as_ref()],bump, payer = authority, space= 32+32)]
+    #[account(init_if_needed ,seeds = [PREFIX.as_bytes(),mint.key().as_ref()],bump, payer = authority, space= 8 + std::mem::size_of::<MintData>())]
     pub mint_data: Account<'info, MintData>,
     pub system_program: Program<'info, System>,
 }

--- a/programs/rarity/src/lib.rs
+++ b/programs/rarity/src/lib.rs
@@ -18,6 +18,11 @@ mod rarity {
 
     pub fn add_metadata(ctx: Context<AddMetadata> , rarity : RarityChart) -> ProgramResult {
         let state = &mut ctx.accounts.mint_data;
+
+        if *ctx.accounts.authority.key != CENTRAL_AUTHORITY.key(){
+            return Err(ErrorCode::Unauthorized.into());
+        }
+
         state.rarity = rarity;
         state.authority = ctx.accounts.authority.to_account_info().key();
         Ok(())
@@ -25,6 +30,11 @@ mod rarity {
 
     pub fn update_metadata(ctx: Context<UpdateMetadata> ,  rarity : RarityChart) -> ProgramResult {
         let state = &mut ctx.accounts.mint_data;
+
+        if *ctx.accounts.authority.key != CENTRAL_AUTHORITY.key(){
+            return Err(ErrorCode::Unauthorized.into());
+        }
+        
         state.rarity = rarity;
         Ok(())
     }
@@ -39,7 +49,6 @@ pub struct UpdateMetadata<'info> {
         bump
     )]
     pub mint_data: ProgramAccount<'info, MintData>,
-    #[account(constraint = authority.key == &CENTRAL_AUTHORITY.key() @ErrorCode::Unauthorized)]
     pub authority: Signer<'info>,
     pub mint: Account<'info, Mint>
 }
@@ -47,7 +56,7 @@ pub struct UpdateMetadata<'info> {
 
 #[derive(Accounts)]
 pub struct AddMetadata<'info> {
-    #[account(signer,constraint = authority.key == &CENTRAL_AUTHORITY.key() @ErrorCode::Unauthorized)]
+    #[account(signer)]
     pub authority: AccountInfo<'info>,
     pub mint: Account<'info, Mint>,
     #[account(init_if_needed ,seeds = [PREFIX.as_bytes(),mint.key().as_ref()],bump, payer = authority, space= 8 + std::mem::size_of::<MintData>())]

--- a/programs/rarity/src/lib.rs
+++ b/programs/rarity/src/lib.rs
@@ -1,16 +1,21 @@
 
 use anchor_lang::prelude::*;
 use anchor_spl::token::Mint;
-
+use anchor_lang::solana_program::pubkey::Pubkey;
 
 declare_id!("5xYiyYKXxh2DNinm2PF6oUgkskF1aaRbKX753FYit5AJ");
 
 const PREFIX: &str = "n_metadata";
+const CENTRAL_AUTHORITY: anchor_lang::prelude::Pubkey = Pubkey::new_from_array(
+    [5, 160, 181, 17, 63, 223, 239, 157, 145, 118, 246, 79, 
+                56, 54, 65, 214, 202, 196, 172, 187,19, 146, 47, 240, 78, 
+                151, 162, 116, 135, 21, 104, 11]);
 
 #[program]
 mod rarity {
     use super::*;
-    
+
+
     pub fn add_metadata(ctx: Context<AddMetadata> , rarity : RarityChart) -> ProgramResult {
         let state = &mut ctx.accounts.mint_data;
         state.rarity = rarity;
@@ -34,6 +39,7 @@ pub struct UpdateMetadata<'info> {
         bump
     )]
     pub mint_data: ProgramAccount<'info, MintData>,
+    #[account(constraint = authority.key == &CENTRAL_AUTHORITY.key() @ErrorCode::Unauthorized)]
     pub authority: Signer<'info>,
     pub mint: Account<'info, Mint>
 }
@@ -41,7 +47,7 @@ pub struct UpdateMetadata<'info> {
 
 #[derive(Accounts)]
 pub struct AddMetadata<'info> {
-    #[account(signer)]
+    #[account(signer,constraint = authority.key == &CENTRAL_AUTHORITY.key() @ErrorCode::Unauthorized)]
     pub authority: AccountInfo<'info>,
     pub mint: Account<'info, Mint>,
     #[account(init_if_needed ,seeds = [PREFIX.as_bytes(),mint.key().as_ref()],bump, payer = authority, space= 8 + std::mem::size_of::<MintData>())]
@@ -49,11 +55,10 @@ pub struct AddMetadata<'info> {
     pub system_program: Program<'info, System>,
 }
 
-
 #[account]
 pub struct MintData {
     pub rarity: RarityChart,
-    pub authority: Pubkey,
+    pub authority: Pubkey
 }
 
 
@@ -64,6 +69,13 @@ pub enum RarityChart {
     Rare,
     UltraRare,
     Legendary
+}
+
+
+#[error]
+pub enum ErrorCode {
+    #[msg("You are not authorized to call this action.")]
+    Unauthorized
 }
 
 

--- a/tests/pda.ts
+++ b/tests/pda.ts
@@ -35,9 +35,7 @@ describe('pda', () => {
       TOKEN_PROGRAM_ID
     );
 
-
-
-    const tokenAccount = await mint.createAccount(provider.wallet.publicKey);
+    const tokenAccount = await mint.createAccount(payer.publicKey);
     await mint.mintTo(
       tokenAccount,
       mintAuthority.publicKey,
@@ -47,7 +45,7 @@ describe('pda', () => {
 
     mintAddresss = mint.publicKey.toBase58();
     const prefix = "n_metadata";
-    const [mintPda, _] = await PublicKey.findProgramAddress(
+    const [mintPda, bump] = await PublicKey.findProgramAddress(
       [
         Buffer.from(anchor.utils.bytes.utf8.encode(prefix)),
         mint.publicKey.toBuffer(),
@@ -135,6 +133,40 @@ describe('pda', () => {
         mint: mintAddresss,
         mintData: mintPda
       },
+    })
+
+    let mintData = await program.account.mintData.fetch(
+      mintPda
+    );
+
+    assert.deepEqual(mintData.rarity,rarity);
+  });
+
+  it('Add with different central authority', async () => {
+
+    //To test fail case change the 
+    const wallet = Keypair.generate();
+    const address = new anchor.web3.PublicKey("3h6p8BMtUmADUEUeeRZK2PcEbS1eDzvjwfpCLVExSGmY");
+    const prefix = "n_metadata";
+    const [mintPda] = await PublicKey.findProgramAddress(
+      [
+        Buffer.from(anchor.utils.bytes.utf8.encode(prefix)),
+        address.toBuffer(),
+      ],
+      program.programId
+    );
+
+    const rarity = {
+      uncommon: {},
+    };
+    
+    await program.rpc.addMetadata(rarity,{
+      accounts: {
+        authority: provider.wallet.publicKey,
+        mint: mintAddresss,
+        mintData: mintPda,
+        systemProgram: SystemProgram.programId,
+      }
     })
 
     let mintData = await program.account.mintData.fetch(


### PR DESCRIPTION
1. https://github.com/heisenberglit/anchor_example/blob/main/programs/rarity/src/lib.rs#L47 space= 32+32 use std::mem::size_of::<MintData>() so it's less coupled (this gets more difficult if you have variable sizing but for now this should work well and be less of a maintenance headache
2.. https://github.com/heisenberglit/anchor_example/blob/main/programs/rarity/src/lib.rs#L17 the authority should be set at a higher level. Since we're using PDAs an adversary could come in, add metadata for a x, and set themselves at the authority. So having it done this way creates security concerns (granted this is minor, but worth fixing)
3. higher level authority should be checked for both instructions, return an Error code if authority did not sign or does not match